### PR TITLE
Add missing connectors

### DIFF
--- a/czertainly-compose.yml
+++ b/czertainly-compose.yml
@@ -8,7 +8,7 @@ services:
 
   opa:
     container_name: opa
-    image: openpolicyagent/opa:0.53.0-rootless
+    image: openpolicyagent/opa:1.5.1-static
     restart: unless-stopped
     ports:
       - 8181:8181
@@ -20,6 +20,7 @@ services:
     command:
       - "run"
       - "--server"
+      - "--addr=0.0.0.0:8181"
       - "--log-format=json-pretty"
       - "--set=decision_logs.console=true"
       - "--set=services.nginx.url=http://opa-bundles:8080"

--- a/czertainly-compose.yml
+++ b/czertainly-compose.yml
@@ -115,6 +115,17 @@ services:
       - core
       - all
 
+  utils:
+    container_name: utils
+    image: czertainly-utils
+    build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-Utils-Service
+    restart: unless-stopped
+    ports:
+      - 8110:8080
+    profiles:
+      - all
+      - utils
+
   core:
     container_name: core
     image: 3keycompany/czertainly-core:develop-latest
@@ -172,6 +183,39 @@ services:
       - JDBC_PASSWORD=${DB_PASSWORD}
     profiles:
       - ejbca-ng-connector-standalone
+      - all
+
+  pyadcs-connector:
+    container_name: pyadcs-connector
+    image: czertainly-pyadcs-connector
+    build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-PyADCS-Connector
+    ports:
+      - 8211:8080
+    environment:
+      - DATABASE_HOST=${DB_HOST}
+      - DATABASE_PORT=${DB_PORT}
+      - DATABASE_NAME=${DB_NAME}
+      - DATABASE_USER=${DB_USERNAME}
+      - DATABASE_PASSWORD=${DB_PASSWORD}
+      - DATABASE_SCHEMA=pyadcs
+    profiles:
+      - pyadcs-connector-standalone
+      - all
+
+  hashicorp-vault-connector:
+    container_name: hashicorp-vault-connector
+    image: czertainly-hashicorp-vault-connector
+    build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-HashiCorp-Vault-Connector
+    ports:
+      - 8212:8080
+    environment:
+      - DATABASE_HOST=${DB_HOST}
+      - DATABASE_PORT=${DB_PORT}
+      - DATABASE_NAME=${DB_NAME}
+      - DATABASE_USER=${DB_USERNAME}
+      - DATABASE_PASSWORD=${DB_PASSWORD}
+    profiles:
+      - hashicorp-vault-connector-standalone
       - all
 
   # ejbca-legacy-connector:
@@ -246,6 +290,21 @@ services:
     profiles:
       - cryptosense-discovery-provider-standalone
       - all
+  ct-logs-discovery-provider:
+    container_name: ct-logs-discovery-provider
+    image: czertainly-ct-logs-discovery-provider
+    build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-CT-Logs-Discovery-Provider
+    ports:
+      - 8242:8080
+    environment:
+      - DATABASE_HOST=${DB_HOST}
+      - DATABASE_PORT=${DB_PORT}
+      - DATABASE_NAME=${DB_NAME}
+      - DATABASE_USER=${DB_USERNAME}
+      - DATABASE_PASSWORD=${DB_PASSWORD}
+    profiles:
+      - ct-logs-discovery-provider-standalone
+      - all
 
   x509-compliance-provider:
     container_name: x509-compliance-provider
@@ -275,15 +334,15 @@ services:
       - email-notification-provider-standalone
       - all
 
-  # interface-docs:
-  #   container_name: interface-docs
-  #   image: czertainly-interface-docs
-  #   build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-Interface-Documentation
-  #   ports:
-  #   - 8300:80
-  #   profiles:
-  #     - interface-docs-standalone
-  #     - all
+  interface-docs:
+    container_name: interface-docs
+    image: czertainly-interface-docs
+    build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-Interface-Documentation
+    ports:
+    - 8300:80
+    profiles:
+      - interface-docs-standalone
+      - all
 
   ejbca:
     container_name: ejbca

--- a/czertainly-compose.yml
+++ b/czertainly-compose.yml
@@ -8,7 +8,7 @@ services:
 
   opa:
     container_name: opa
-    image: openpolicyagent/opa:1.5.1-static
+    image: openpolicyagent/opa:1.9.0-static
     restart: unless-stopped
     ports:
       - 8181:8181
@@ -36,7 +36,7 @@ services:
 
   rabbitmq:
     container_name: rabbitmq
-    image: rabbitmq:3.12.0-management
+    image: rabbitmq:3.13.7-management-alpine
     restart: unless-stopped
     ports:
       - 5672:5672
@@ -254,6 +254,7 @@ services:
     container_name: software-cryptography-provider
     image: czertainly-software-cryptography-provider
     build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-Software-Cryptography-Provider
+    restart: unless-stopped
     ports:
       - 8230:8080
     environment:
@@ -268,6 +269,7 @@ services:
     container_name: ip-discovery-provider
     image: czertainly-ip-discovery-provider
     build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-IP-Discovery-Provider
+    restart: unless-stopped
     ports:
       - 8240:8080
     environment:
@@ -311,6 +313,7 @@ services:
     container_name: x509-compliance-provider
     image: czertainly-x509-compliance-provider
     build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-X509-Compliance-Provider
+    restart: unless-stopped
     ports:
       - 8250:8080
     profiles:
@@ -333,6 +336,21 @@ services:
       - SMTP_PASSWORD=${SMTP_PASSWORD}
     profiles:
       - email-notification-provider-standalone
+      - all
+  
+  webhook-notification-provider:
+    container_name: webhook-notification-provider
+    image: czertainly-webhook-notification-provider
+    build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-Webhook-Notification-Provider
+    restart: unless-stopped
+    ports:
+      - 8261:8080
+    environment:
+      - JDBC_URL=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+      - JDBC_USERNAME=${DB_USERNAME}
+      - JDBC_PASSWORD=${DB_PASSWORD}
+    profiles:
+      - webhook-notification-provider-standalone
       - all
 
   interface-docs:

--- a/czertainly-compose.yml
+++ b/czertainly-compose.yml
@@ -190,6 +190,7 @@ services:
     container_name: pyadcs-connector
     image: czertainly-pyadcs-connector
     build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-PyADCS-Connector
+    restart: unless-stopped
     ports:
       - 8211:8080
     environment:
@@ -207,6 +208,7 @@ services:
     container_name: hashicorp-vault-connector
     image: czertainly-hashicorp-vault-connector
     build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-HashiCorp-Vault-Connector
+    restart: unless-stopped
     ports:
       - 8212:8080
     environment:
@@ -297,6 +299,7 @@ services:
     container_name: ct-logs-discovery-provider
     image: czertainly-ct-logs-discovery-provider
     build: ${CZERTAINLY_SOURCES_BASE_DIR}/CZERTAINLY-CT-Logs-Discovery-Provider
+    restart: unless-stopped
     ports:
       - 8242:8080
     environment:


### PR DESCRIPTION
This pull request updates the `czertainly-compose.yml` file with several improvements, including upgrading service images, adding new connectors and providers, and enhancing service reliability. The changes help ensure better compatibility, easier extensibility, and more robust service management.

**Service upgrades:**

* Updated the `opa` service to use the `openpolicyagent/opa:1.9.0-static` image and added the `--addr=0.0.0.0:8181` flag for explicit address binding. [[1]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2L11-R11) [[2]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2R23)
* Upgraded the `rabbitmq` service to `rabbitmq:3.13.7-management-alpine` for improved performance and security.

**New connectors and providers:**

* Added new services: `utils`, `pyadcs-connector`, `hashicorp-vault-connector`, and `ct-logs-discovery-provider`, each with their own build contexts, ports, environment variables, and profiles for improved modularity and integration. [[1]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2R119-R129) [[2]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2R189-R221) [[3]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2R296-R316)

**Reliability improvements:**

* Added the `restart: unless-stopped` property to several services (`software-cryptography-provider`, `ip-discovery-provider`, `x509-compliance-provider`, and `webhook-notification-provider`) to increase service reliability in case of unexpected failures. [[1]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2R257) [[2]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2R272) [[3]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2R296-R316) [[4]](diffhunk://#diff-15c7bef931c8c3a4f2d82c1a484a482094047d2c1c4af874ceabea2513d0aaa2L278-R364)

**Notification and documentation services:**

* Introduced the `webhook-notification-provider` service with database environment variables, and restored the `interface-docs` service for API documentation, both with appropriate profiles and port mappings.