### PR TITLE
Update Postgres Docker compose project and related environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 CZERTAINLY_SOURCES_BASE_DIR=/dir/with/source/repositories
-DB_HOST=host.docker.internal
-DB_PORT=2345
+DB_HOST=postgres
+# DB_HOST=host.docker.internal # use in case of connecting to Postgres installed on host machine
+DB_PORT=5432
+DB_HOST_PORT=2345
 DB_USERNAME=czertainlyuser
 DB_PASSWORD=your-strong-password
 DB_NAME=czertainly

--- a/czertainly-compose.yml
+++ b/czertainly-compose.yml
@@ -8,7 +8,7 @@ services:
 
   opa:
     container_name: opa
-    image: openpolicyagent/opa:1.9.0-static
+    image: openpolicyagent/opa:1.10.0-static
     restart: unless-stopped
     ports:
       - 8181:8181
@@ -36,7 +36,7 @@ services:
 
   rabbitmq:
     container_name: rabbitmq
-    image: rabbitmq:3.13.7-management-alpine
+    image: rabbitmq:4.2.0-management-alpine
     restart: unless-stopped
     ports:
       - 5672:5672

--- a/postgres-compose.yml
+++ b/postgres-compose.yml
@@ -1,20 +1,17 @@
-name: czertainly-database
+name: czertainly
 
 services:
 
   postgres:
     container_name: postgres
-    image: postgres:15-alpine
+    image: postgres:17-alpine
     restart: unless-stopped
-    build: ./services/postgres
     ports:
-      - ${DB_PORT}:5432
+      - ${DB_HOST_PORT}:${DB_PORT}
     environment:
       - POSTGRES_USER=${DB_USERNAME}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
       - POSTGRES_DB=${DB_NAME}
-      - PGUSER=${DB_USERNAME}
-      - PGDATABASE=${DB_NAME}
     volumes:
       - ./data/postgres/pgsqldata:/var/lib/postgresql/data:delegated
     healthcheck:
@@ -26,47 +23,11 @@ services:
       - database
       - all
 
-  auth:
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  core:
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  scheduler:
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  ejbca-ng-connector:
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  keystore-entity-provider:
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  software-cryptography-provider:
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  ip-discovery-provider:
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  cryptosense-discovery-provider:
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  email-notification-provider:
-    depends_on:
-      postgres:
-        condition: service_healthy
+  adminer:
+    container_name: postgres-adminer
+    image: adminer:latest
+    restart: unless-stopped
+    ports:
+      - 8088:8080
+    profiles:
+      - all


### PR DESCRIPTION
- changed default DB host to 'postgres' and updated port variables in .env.example.
- upgraded OPA and RabbitMQ images in czertainly-compose.yml.
- updated Postgres image to 17-alpine
- adjusted port mapping, removed unused build and environment variables
- added Adminer service in postgres-compose.yml
- removed redundant 'depends_on' sections for other services.