### PR TITLE
Need to run Vault as a service dependency

### DIFF
--- a/czertainly-compose.yml
+++ b/czertainly-compose.yml
@@ -238,6 +238,45 @@ services:
       - pyadcs-connector-standalone
       - all
 
+  vault:
+    image: hashicorp/vault:latest
+    container_name: vault
+    restart: on-failure:10
+    ports:
+      - "8201:8201"
+    environment:
+      VAULT_ADDR: 'http://0.0.0.0:8201'
+      VAULT_LOCAL_CONFIG: '{"listener": [{"tcp":{"address": "0.0.0.0:8201","tls_disable":"1"}}], "default_lease_ttl": "168h", "max_lease_ttl": "720h"}, "ui": true}'
+      VAULT_DEV_ROOT_TOKEN_ID: '00000000-0000-0000-0000-000000000000'
+      VAULT_TOKEN: '00000000-0000-0000-0000-000000000000'
+    cap_add:
+      - IPC_LOCK
+    privileged: true
+    healthcheck:
+      test: ["CMD", "vault", "status"]
+      interval: 5s
+      retries: 5
+    command: server -dev -dev-root-token-id="00000000-0000-0000-0000-000000000000"
+    profiles:
+      - hashicorp-vault-connector-deps
+      - hashicorp-vault-connector-standalone
+
+  vault-init:
+    image: hashicorp/vault:latest
+    depends_on:
+      vault:
+        condition: service_healthy
+    environment:
+      VAULT_ADDR: http://vault:8201
+      VAULT_TOKEN: '00000000-0000-0000-0000-000000000000'
+    volumes:
+      - ./files/vault-init.sh:/vault-init.sh:ro,Z
+      - ./files/vault-test-policy.hcl:/vault-test-policy.hcl:ro,Z
+    entrypoint: ["sh", "/vault-init.sh"]
+    profiles:
+      - hashicorp-vault-connector-deps
+      - hashicorp-vault-connector-standalone
+
   hashicorp-vault-connector:
     container_name: hashicorp-vault-connector
     image: czertainly-hashicorp-vault-connector
@@ -246,11 +285,13 @@ services:
     ports:
       - 8212:8080
     environment:
+      - LOG_LEVEL=DEBUG
       - DATABASE_HOST=${DB_HOST}
       - DATABASE_PORT=${DB_PORT}
       - DATABASE_NAME=${DB_NAME}
       - DATABASE_USER=${DB_USERNAME}
       - DATABASE_PASSWORD=${DB_PASSWORD}
+      - DATABASE_SSL_MODE=disable
     healthcheck:
       test: wget -O - http://localhost:8080/v1/health | grep -q '{"status":"ok"}'
       interval: 10s
@@ -259,6 +300,9 @@ services:
     profiles:
       - hashicorp-vault-connector-standalone
       - all
+    depends_on:
+      vault:
+        condition: service_healthy
 
   # ejbca-legacy-connector:
   #   container_name: ejbca-legacy-connector

--- a/files/vault-init.sh
+++ b/files/vault-init.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+# create kv v1 and v2 mounts, together with the default `secret/` kv v2 mount
+# there'll be two kv mounts for each version and one pair of v1 and v2 versions
+# will have a common path prefix
+vault secrets enable -path=legacy kv
+vault secrets enable -path=common/version1 kv
+vault secrets enable -path=common/version2 kv-v2
+
+# create a policy `test-policy`
+vault policy write test-policy vault-test-policy.hcl
+
+# enable approle
+vault auth enable approle
+
+# create named role
+vault write auth/approle/role/ilm-connector \
+    token_policies="test-policy" \
+    token_type=default \
+    secret_id_ttl=365d \
+    token_ttl=365d \
+    token_max_ttl=365d \
+    secret_id_num_uses=4000 \
+    token_num_uses=0
+
+# verify policy
+vault read auth/approle/role/ilm-connector

--- a/files/vault-test-policy.hcl
+++ b/files/vault-test-policy.hcl
@@ -1,0 +1,35 @@
+# Allow read/write/list on KV v2 secrets
+path "secret/data/*" {
+  capabilities = ["create", "update", "read", "delete"]
+}
+
+path "secret/metadata/*" {
+  capabilities = ["list", "read", "delete"]
+}
+
+path "common/version2/data/*" {
+  capabilities = ["create", "update", "read", "delete"]
+}
+
+path "common/version2/metadata/*" {
+  capabilities = ["list", "read", "delete"]
+}
+
+# Allow read/write/list on KV v1 secrets
+path "common/version1/*" {
+  capabilities = ["create", "update", "read", "delete"]
+}
+
+path "legacy/*" {
+  capabilities = ["create", "update", "read", "delete"]
+}
+
+# Allow listing mounts
+path "sys/mounts" {
+  capabilities = ["read"]
+}
+
+# Allow reading specific mount configuration (optional but useful)
+path "sys/mounts/*" {
+  capabilities = ["read"]
+}


### PR DESCRIPTION
With the addition of implementation of Secrets Provider to the `CZERTAINLY-HashiCorp-Vault-Connector` it is important that the Vault dependency is run and properly configured.