### PR TITLE
Add provider.status-poll queue and binding

### DIFF
--- a/rabbitmq/definitions.json
+++ b/rabbitmq/definitions.json
@@ -86,6 +86,14 @@
             }
         },
         {
+            "name": "provider.status-poll",
+            "vhost": "/",
+            "durable": true,
+            "auto_delete": false,
+            "arguments": {
+            }
+        },
+        {
             "name": "core",
             "vhost": "/",
             "durable": true,
@@ -174,6 +182,15 @@
             "destination": "core.events",
             "destination_type": "queue",
             "routing_key": "event",
+            "arguments": {
+            }
+        },
+        {
+            "source": "ilm",
+            "vhost": "/",
+            "destination": "provider.status-poll",
+            "destination_type": "queue",
+            "routing_key": "provider.status-poll",
             "arguments": {
             }
         },


### PR DESCRIPTION
Adds the plain durable `provider.status-poll` queue and its `ilm`-exchange binding to the local RabbitMQ definitions, so OmniTrustILM/core's async certificate-status polling (OmniTrustILM/core#1602) can consume/publish on it when running the platform locally.

Mirrors the existing `core.*` entries; no delayed-message plugin or delayed exchange. `definitions.json` re-validated as well-formed JSON.

Closes #21
Part of epic OmniTrustILM/ilm#110.
